### PR TITLE
Allow an optional data array to be passed as the 2nd argument in the …

### DIFF
--- a/src/Crhayes/BladePartials/Factory.php
+++ b/src/Crhayes/BladePartials/Factory.php
@@ -27,7 +27,7 @@ class Factory extends \Illuminate\View\Factory {
 
         }else{
             //params passed
-            $vars = array_merge($vars,$arg3);
+            $vars = array_merge($arg3,$vars);
             $callback=$arg4;
         }
 		$callback($file, $vars);

--- a/src/Crhayes/BladePartials/Factory.php
+++ b/src/Crhayes/BladePartials/Factory.php
@@ -16,11 +16,20 @@ class Factory extends \Illuminate\View\Factory {
 	 * 
 	 * @param  string 	$file
 	 * @param  array 	$vars
-	 * @param  closure 	$callback
+	 * @param  array|closure 	$arg3
+	 * @param  closure|bool 	$arg4
 	 * @return void
 	 */
-	public function renderPartial($file, $vars, $callback)
+	public function renderPartial($file, $vars, $arg3, $arg4 = false)
 	{
+        if(!$arg4){
+            $callback=$arg3;
+
+        }else{
+            //params passed
+            $vars = array_merge($vars,$arg3);
+            $callback=$arg4;
+        }
 		$callback($file, $vars);
 
 		$this->flushBlocks();


### PR DESCRIPTION
Enables optional data array to be passed to the partial in the same way as native '@include' calls e.g.

In a view

```
@partial('matter.organisms.strip',['element'=>'header'])
...
```

Partial definition

```
<{{$element}} class="strip">
...
```

Due the nature of the createOpenMatcher regex I've had to account for a different number of parameters and types coming in which isn't ideal I know.  Must be a better way.
